### PR TITLE
Fix duplicate "Infra::Other" category in classification list

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -84,7 +84,6 @@
     "Infra::RaaS (Rollup as a Service)",
     "Infra::WaaS",
     "Infra::Wallet",
-    "Infra::Other",
     "NFT::Collections",
     "NFT::Infrastructure",
     "NFT::Interoperability",


### PR DESCRIPTION
Removed the duplicate "Infra::Other" entry from the categories list. Having duplicate categories can cause confusion during classification, lead to inconsistent data tagging, and potentially create problems in any filtering or analytics systems that rely on these category values.

<img width="670" alt="image" src="https://github.com/user-attachments/assets/459e54ba-dc03-40ec-bb56-dcadab10ddec" />
