### PR TITLE
Fix path reference in log message

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -58,7 +58,7 @@ jobs:
         try {
           const categoriesData = JSON.parse(fs.readFileSync('./categories.json', 'utf8'));
           CATEGORIES = categoriesData.categories;
-          console.log(`📋 Loaded ${CATEGORIES.length} valid categories from .github/categories.json`);
+          console.log(`📋 Loaded ${CATEGORIES.length} valid categories from categories.json`);
         } catch (error) {
           console.log(`❌ Error loading categories file: ${error.message}`);
           process.exit(1);


### PR DESCRIPTION
Update the log message to correctly reference 'categories.json' instead of '.github/categories.json' to match the actual file path used in the code.