### PR TITLE
Fix links in Anima.json

### DIFF
--- a/testnet/Anima.json
+++ b/testnet/Anima.json
@@ -12,6 +12,6 @@
     "links": {
         "project": "https://anima.io",
         "twitter": "https://x.com/anima_protocol",
-        "docs": "https://docs.pop.anima.io/reputation/integrate"
+        "docs": "https://docs.pop.anima.io/reputation/legacy/integrate"
     }
 }


### PR DESCRIPTION
The link in Anima.json was a 404; it's now fixed. Everything should work great now