### PR TITLE
Remove extra space in Spine Finance description

### DIFF
--- a/testnet/Spine_Finance.json
+++ b/testnet/Spine_Finance.json
@@ -1,6 +1,6 @@
 {
     "name": "Spine Finance",
-    "description": " Instant, Efficient, and Flexible Fixed-Rate Money Markets.",
+    "description": "Instant, Efficient, and Flexible Fixed-Rate Money Markets.",
     "live": true,
     "categories": ["DeFi::Lending"],
     "addresses": {


### PR DESCRIPTION
PR removes an unnecessary leading space in the description field of the Spine_Finance.json file