### PR TITLE
chore: remove dead GitHub repo link

### DIFF
--- a/testnet/Kintsu.json
+++ b/testnet/Kintsu.json
@@ -9,7 +9,6 @@
     "links": {
         "project": "https://kintsu.xyz/",
         "twitter": "https://x.com/kintsu_xyz",
-        "github": "https://github.com/WaterCoolerStudiosInc/monad-contracts",
         "docs": "https://docs.kintsu.xyz/"
     }
 }


### PR DESCRIPTION
noticed that the link to the project's GitHub repo returns a 404.
i went ahead and removed it to avoid confusion.
