### PR TITLE
Updated the links

### DIFF
--- a/testnet/LEVR.bet.json
+++ b/testnet/LEVR.bet.json
@@ -5,8 +5,8 @@
     "categories": ["Consumer::Betting"],
     "addresses": {},
     "links": {
-        "project": "LEVR.bet",
-        "twitter": "https://x.com/levr_bet?s=21&t=JIlDCK86kLdwskhmlNezFQ",
-        "docs": "https://app.gitbook.com/o/5F4trDfUVgfFvDWbJYCv/sites/site_xsj7f/"
+        "project": "https://www.levr.bet",
+        "twitter": "https://x.com/LEVR_bet",
+        "docs": "https://www.levr.bet/whitepaper"
     }
 }

--- a/testnet/NadSmith.json
+++ b/testnet/NadSmith.json
@@ -5,7 +5,7 @@
     "categories": ["AI::Compute"],
     "addresses": {},
     "links": {
-        "project": "https://x.com/NadSmith_",
+        "project": "https://nadsmith.ai/",
         "twitter": "https://x.com/NadSmith_"
     }
 }


### PR DESCRIPTION
updated the links to point to the correct site + whitepaper
also checked with the team — turns out the whitepaper currently serves as the main documentation