### PR TITLE
Update docs URL in sidekick.json

### DIFF
--- a/testnet/sidekick.json
+++ b/testnet/sidekick.json
@@ -11,6 +11,6 @@
         "project": "https://sidekick.fans/",
         "twitter": "https://x.com/Sidekick_Labs",
         "github": "https://github.com/SidekickOfficial/SmartContracts",
-        "docs": "https://github.com/SidekickOfficial/SmartContracts"
+        "docs": "https://sidekick-protocol.gitbook.io/sidekick"
     }
 }


### PR DESCRIPTION
Replaced the outdated GitHub documentation link with the new GitBook URL:
https://sidekick-protocol.gitbook.io/sidekick