### PR TITLE
Add Monport miniapp protocol with NFT contract and swap info

### DIFF
--- a/monport.json
+++ b/monport.json
@@ -1,11 +1,16 @@
 {
   "name": "Monport",
-  "website": "https://farcaster.xyz/miniapps/hmwIYVBTwm5z/monport",
-  "description": "A Farcaster miniapp on Monad that allows users to mint a unique NFT (\"WelcomeMonad\") and perform token swaps via integrated protocols like KuruSwap.",
-  "category": "nft",
-  "contracts": [
-    "0x40649af9dEE8bDB94Dc21BA2175AE8f5181f14AE"
+  "description": "A Farcaster miniapp on Monad that allows users to mint a unique NFT collection called 'WelcomeMonad' and perform token swaps via integrated protocols like KuruSwap.",
+  "categories": [
+    "NFT::Collections",
+    "DeFi::DEX"
   ],
-  "twitter": "https://x.com/Aren_ser",
-  "github": "https://github.com/Aren1414"
+  "addresses": {
+    "WelcomeMonad": "0x40649af9dEE8bDB94Dc21BA2175AE8f5181f14AE"
+  },
+  "links": {
+    "project": "https://farcaster.xyz/miniapps/hmwIYVBTwm5z/monport",
+    "twitter": "https://x.com/Aren_ser",
+    "github": "https://github.com/Aren1414"
+  }
 }

--- a/monport.json
+++ b/monport.json
@@ -1,0 +1,11 @@
+{
+  "name": "Monport",
+  "website": "https://farcaster.xyz/miniapps/hmwIYVBTwm5z/monport",
+  "description": "A Farcaster miniapp on Monad that allows users to mint a unique NFT (\"WelcomeMonad\") and perform token swaps via integrated protocols like KuruSwap.",
+  "category": "nft",
+  "contracts": [
+    "0x40649af9dEE8bDB94Dc21BA2175AE8f5181f14AE"
+  ],
+  "twitter": "https://x.com/Aren_ser",
+  "github": "https://github.com/Aren1414"
+}


### PR DESCRIPTION
This PR adds the `Monport` miniapp protocol to the Monad Foundation registry.

Monport is a Farcaster miniapp built on Monad that allows users to:
- Mint a unique NFT collection called 'WelcomeMonad'
- Perform token swaps via integrated protocols like 'KuruSwap'

The JSON file includes all required metadata: website, category, NFT contract address, and social links