### PR TITLE
updated the link to the current URL

### DIFF
--- a/testnet/MemeAIAssistant.json
+++ b/testnet/MemeAIAssistant.json
@@ -7,7 +7,7 @@
     "Meme NFT": "0x36a9305Eb14906A3676F772375d59b3495dA9c1E"
   },
   "links": {
-    "project": "https://meme-ai-assistant.archlab.space/landing",
+    "project": "https://go2blockchains.vercel.app/",
     "twitter": "https://x.com/archlab_space",
     "farcaster": "https://farcaster.xyz/miniapps/bJ_dfhkjZK58/monad-meme-ai-assistant"
   }


### PR DESCRIPTION
updated the link to the current URL.

p.s. correct link is go2blockchains.vercel.app